### PR TITLE
Adding travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+
+go:
+  - 1.2
+
+install:
+  - go get launchpad.net/goamz/aws
+  - go get -v -t ./... 
+  - mkdir -p $HOME/gopath/bin
+  - go install
+
+script:
+ - export PATH=$HOME/gopath/bin:$PATH
+ - go test ./...


### PR DESCRIPTION
Using http://docs.travis-ci.com/user/languages/go/ as CI.

Tested it on my fork. 

Next step would be enabling travis for realestate-com-au/credulous and maybe adding "build status" to README
