### PR TITLE
Example how to install using brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ workflow.
 
 Download your [platform specific app](https://github.com/realestate-com-au/credulous/releases)
 
+### Using brew
+
+If you are using brew you can use:
+
+``` 
+brew install https://raw.githubusercontent.com/realestate-com-au/credulous/master/brew/credulous.rb 
+```
+
 ## Usage
 
 Storing your current credentials in Credulous


### PR DESCRIPTION
As mentioned in #16, I would like to have an easy way of installing credulous. 

Turns out, we can host our own brew formula and point users to use it. 
