### PR TITLE
Add goconvey installation step.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Install the binary in your $GOBIN
 First we make sure we have our dependencies
 
     go get -t
+    
+Make sure goconvey is installed, else use
+
+    go get -t github.com/smartystreets/goconvey
 
 Just go into this directory and either
 


### PR DESCRIPTION
README.md misses a step in setting up goconvey, adding it to make the documentation more explicit.
